### PR TITLE
Added ability to pass in custom max header size for NodeJS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:11-alpine
 
+ARG MAX_HEADER_SIZE
 ENV CHROME_BIN="/usr/bin/chromium-browser" \
-    NODE_ENV="production"
+    NODE_ENV="production" \
+    MAX_HEADER_SIZE=${MAX_HEADER_SIZE}
 RUN set -x \
     && apk update \
     && apk upgrade \

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
-    "start": "node src/index.js",
+    "start": "./start.sh",
     "test": "mocha",
     "precommit": "lint-staged"
   },

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+node --max-http-header-size ${MAX_HEADER_SIZE} src/index.js


### PR DESCRIPTION
- Added `MAX_HEADER_SIZE` ARG and ENV to Dockerfile
- Changed `package.json` `start` to run `start.sh` script
- Added `start.sh` script to run Node.js with `MAX_HEADER_SIZE` variable